### PR TITLE
[New Feature] Implement `lru-cache` for backend requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ At full power, this app will let you visualize your Spotify playlists in the sam
 - **Backend**: Node.js, Express, TypeScript
 - **AI**: OpenAI API
 - **Music**: Spotify API
+- **Caching**: `lru-cache`
 - **3D Rendering** Three.js, GLSL
   - **NB**: when installing `vite-plugin-glslify`, until something gets fixed in their code, you need to install this using `npm install vite-plugin-glslify --legacy-peer-deps` to ensure that this plugin can support `vite 6`.
 
@@ -45,7 +46,7 @@ Run two terminals, one for the frontend and one for the backend.
 
 ### Frontend
 * `cd frontend`
-* `npm install`
+* `npm install --legacy-peer-deps`
 * `npm run dev`
 
 ### Backend

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "lru-cache": "^11.1.0",
         "openai": "^4.98.0",
         "spotify-web-api-node": "^5.0.2",
         "ts-node": "^10.9.2",
@@ -1161,6 +1162,15 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "lru-cache": "^11.1.0",
     "openai": "^4.98.0",
     "spotify-web-api-node": "^5.0.2",
     "ts-node": "^10.9.2",

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -6,10 +6,10 @@ const cache = new LRUCache<string, Analysis>({
   max: 100,
   ttl: 1000 * 60 * 5, // 5 minutes
   onInsert: (value, key, reason) => {
-    logMessage("cache", `Inserted ${value} into cache`);
+    logMessage("cache", `Inserted ${JSON.stringify(key)} into cache`, JSON.stringify(value))
   },
   dispose: (value, key, reason) => {
-    logMessage("cache", `Deleted ${value} from cache`);
+    logMessage("cache", `Deleted ${JSON.stringify(key)} from cache`, JSON.stringify(value));
   }
 
 });

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -1,6 +1,7 @@
 import { LRUCache } from "lru-cache";
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { Analysis } from "@types";
 import { logMessage } from "../services/logging";
 

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -1,0 +1,7 @@
+import { LRUCache } from "lru-cache";
+import { AnalysisResponse } from "@types";
+
+const cache = new LRUCache<string, AnalysisResponse>({
+  max: 100,
+  ttl: 1000 * 60 * 5, // 5 minutes
+});

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from "lru-cache";
+<<<<<<< HEAD
 import { Analysis } from "@types";
 import { logMessage } from "../services/logging";
 
@@ -19,3 +20,11 @@ export const cacheResponse = (key: string, value: Analysis) => {
 };
 
 export const getCachedResponse = (key: string): Analysis | undefined => cache.get(JSON.stringify(key));
+=======
+import { AnalysisResponse } from "@types";
+
+const cache = new LRUCache<string, AnalysisResponse>({
+  max: 100,
+  ttl: 1000 * 60 * 5, // 5 minutes
+});
+>>>>>>> 30282a4 (start building a cache)

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -4,7 +4,7 @@ import { logMessage } from "../services/logging";
 
 const cache = new LRUCache<string, Analysis>({
   max: 100,
-  ttl: 1000 * 60 * 5, // 5 minutes
+  ttl: 1000 * 60 * 60 * 24, // One day
   onInsert: (value, key, reason) => {
     logMessage("cache", `Inserted ${JSON.stringify(key)} into cache`, JSON.stringify(value))
   },

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -1,7 +1,15 @@
 import { LRUCache } from "lru-cache";
-import { AnalysisResponse } from "@types";
+import { Analysis } from "@types";
+import { logMessage } from "../services/logging";
 
-const cache = new LRUCache<string, AnalysisResponse>({
+const cache = new LRUCache<string, Analysis>({
   max: 100,
   ttl: 1000 * 60 * 5, // 5 minutes
+  onInsert: (value, key, reason) => {
+    logMessage("cache", `Inserted ${key} into cache`);
+  },
+  dispose: (value, key, reason) => {
+    logMessage("cache", `Deleted ${key} from cache`);
+  }
+
 });

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -1,7 +1,4 @@
 import { LRUCache } from "lru-cache";
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { Analysis } from "@types";
 import { logMessage } from "../services/logging";
 

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -6,10 +6,16 @@ const cache = new LRUCache<string, Analysis>({
   max: 100,
   ttl: 1000 * 60 * 5, // 5 minutes
   onInsert: (value, key, reason) => {
-    logMessage("cache", `Inserted ${key} into cache`);
+    logMessage("cache", `Inserted ${value} into cache`);
   },
   dispose: (value, key, reason) => {
-    logMessage("cache", `Deleted ${key} from cache`);
+    logMessage("cache", `Deleted ${value} from cache`);
   }
 
 });
+
+export const cacheResponse = (key: string, value: Analysis) => {
+  cache.set(JSON.stringify(key), value);
+};
+
+export const getCachedResponse = (key: string): Analysis | undefined => cache.get(JSON.stringify(key));

--- a/backend/src/cache/cache.ts
+++ b/backend/src/cache/cache.ts
@@ -1,5 +1,6 @@
 import { LRUCache } from "lru-cache";
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { Analysis } from "@types";
 import { logMessage } from "../services/logging";
 
@@ -20,11 +21,3 @@ export const cacheResponse = (key: string, value: Analysis) => {
 };
 
 export const getCachedResponse = (key: string): Analysis | undefined => cache.get(JSON.stringify(key));
-=======
-import { AnalysisResponse } from "@types";
-
-const cache = new LRUCache<string, AnalysisResponse>({
-  max: 100,
-  ttl: 1000 * 60 * 5, // 5 minutes
-});
->>>>>>> 30282a4 (start building a cache)

--- a/backend/src/controllers/analysis.ts
+++ b/backend/src/controllers/analysis.ts
@@ -5,8 +5,8 @@ export class AnalysisController {
     constructor(private openAIService: OpenAIService) {}
 
     async analyze(req: Request, res: Response) {
-        const { tracks } = req.body;
-        const analysis: AnalysisResponse = await this.openAIService.analyzePlaylist(tracks);
+        const { tracksList, id } = req.body;
+        const analysis: AnalysisResponse = await this.openAIService.analyzePlaylist(tracksList, id);
 
         if(analysis.status !== 200) {
             res.status(500).json({ ...analysis })

--- a/backend/src/services/logging.ts
+++ b/backend/src/services/logging.ts
@@ -1,0 +1,6 @@
+export const logMessage = (label: string, log: any, endMessage?: string): void => {
+    console.log("===================================")
+    console.log(label, log)
+    console.log("===================================")
+    if(endMessage) console.log(endMessage)
+}

--- a/backend/src/services/openai.ts
+++ b/backend/src/services/openai.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 import type { Analysis, AnalysisResponse } from "@types";
 import { zodResponseFormat } from "openai/helpers/zod";
+import { logMessage } from "./logging";
 import { z } from "zod";
 
 export class OpenAIService {
@@ -8,13 +9,6 @@ export class OpenAIService {
     
     constructor(apiKey: string) {
         this.openai = new OpenAI({ apiKey });
-    }
-
-    private logMessage(label: string, log: any, endMessage?: string): void {
-        console.log("===================================")
-        console.log(label, log)
-        console.log("===================================")
-        if(endMessage) console.log(endMessage)
     }
 
     async analyzePlaylist(prompt: string[]): Promise<AnalysisResponse> {
@@ -29,7 +23,7 @@ export class OpenAIService {
             colors: z.array(z.string().regex(/^#[0-9A-F]{6}$/i)),
         })
 
-        this.logMessage("prompting...", prompt.join("\n"))
+        logMessage("prompting...", prompt.join("\n"))
 
         try {           
             const res = await this.openai.beta.chat.completions.parse({
@@ -44,14 +38,14 @@ export class OpenAIService {
             const analysis: Analysis | null = res.choices[0].message.parsed;
 
             if(analysis){
-                this.logMessage("finishing", analysis, "done with success")
+                logMessage("finishing", analysis, "done with success")
                 
                 return {
                     analysis,
                     status: 200,
                 };
             } else {
-                this.logMessage("finishing", analysis, "done with error: no analysis")
+                logMessage("finishing", analysis, "done with error: no analysis")
 
                 return {
                     analysis: { 
@@ -61,7 +55,7 @@ export class OpenAIService {
                 }
             }
         } catch(e) {
-            this.logMessage("finishing", e, "done with error")
+           logMessage("finishing", e, "done with error")
 
             return {
                 analysis: {

--- a/backend/src/services/openai.ts
+++ b/backend/src/services/openai.ts
@@ -12,7 +12,7 @@ export class OpenAIService {
         this.openai = new OpenAI({ apiKey });
     }
 
-    async analyzePlaylist(prompt: string[]): Promise<AnalysisResponse> {
+    async analyzePlaylist(prompt: string[], id: string): Promise<AnalysisResponse> {
         const systemPrompt = `
             Here's a playlist. Given this list, generate a gradient of 12 colors that represent the "vibes" of the song list. the vibe can be measured on some combination of the lyrics, the tempo, and the genre. anything that informs the message or general emotions of the songs. The colors should also follow a cohesive color scheme. Pick one color that represents the main theme of the whole and then pick 11 complementary colors that accent and highlight the main theme.
             Tell me what you think the vibe of the playlist is and highlight what emotions, messages, and high-level themes of the songs and how they shape the vibe of the playlist as a whole. Keep your tone light, friendly, and fun. Your analysis should sound casual and conversational, sounding like you're speaking to a friend. Give your analysis in the form of an opinion
@@ -24,8 +24,7 @@ export class OpenAIService {
             colors: z.array(z.string().regex(/^#[0-9a-fA-F]{6}$/i)),
         })
 
-        const cacheKey = JSON.stringify(prompt);
-        const cachedResponse = getCachedResponse(cacheKey);
+        const cachedResponse = getCachedResponse(id);
         if (cachedResponse) {
             return {
                 analysis: cachedResponse,
@@ -50,7 +49,7 @@ export class OpenAIService {
             if (analysis) {
                 logMessage("finishing", analysis, "done with success")
 
-                cacheResponse(cacheKey, analysis);
+                cacheResponse(id, analysis);
                 
                 return {
                     analysis,

--- a/frontend/src/components/PlaylistVisualizer.tsx
+++ b/frontend/src/components/PlaylistVisualizer.tsx
@@ -12,16 +12,16 @@ export default function PlaylistVisualizer() {
     const [loading, setLoading] = useState<boolean>(false);
     const [activeTab, setActiveTab] = useState<string>("visualizer");
 
-    const { tracks, isTracksError } = usePlaylistContext();
+    const { selectedPlaylist, tracks, isTracksError } = usePlaylistContext();
     const analysisService = new AnalysisService();
 
     const tracksList = tracks?.items.map((track) => (`title: ${track.track.name} artist: ${track.track.artists[0].name}`));
 
-    const handleClick = async () => {
+    const handleClick = async (): Promise<void> => {
         if (!tracksList) return;
         setLoading(true);
         setAnalysis(null);
-        const res = await analysisService.getTracksAnalysis(tracksList);
+        const res = await analysisService.getTracksAnalysis({tracksList, id: selectedPlaylist?.id});
         setAnalysis(res.analysis);
         setLoading(false);
     }

--- a/frontend/src/services/analysis.ts
+++ b/frontend/src/services/analysis.ts
@@ -1,7 +1,7 @@
 import type { AnalysisResponse } from "@types";
 
 export class AnalysisService {
-    async getTracksAnalysis(tracks: string[]): Promise<AnalysisResponse> {
+    async getTracksAnalysis({ tracksList, id}: { tracksList: string[], id: string | undefined }): Promise<AnalysisResponse> {
         const res = await fetch("http://127.0.0.1:3000/api/analysis/analyze", {
             method: "POST",
             credentials: "include",
@@ -9,7 +9,7 @@ export class AnalysisService {
                 "Content-Type": "application/json",
                 "Accept": "application/json",
             },
-            body: JSON.stringify({ tracks }),
+            body: JSON.stringify({ tracksList, id }),
         });
         return res.json();
     }


### PR DESCRIPTION
## What? 

This PR adds a caching layer to our app to increase performance a bit and also save us some money by not having to go to OpenAI for every playlist every time we want a color scheme. I also moved logging to its own service so that we can use it in places other than just the AI queries. Specifically, I moved it out so that we can view the entries as they enter the cache.

## How? 

I installed `lru-cache` as a new package to handle our caching logic and I inserted the logic right before the API call.